### PR TITLE
Updated bot docs to include new competitionId arg

### DIFF
--- a/src/config/commands/groups/competition.ts
+++ b/src/config/commands/groups/competition.ts
@@ -1,11 +1,11 @@
 export default {
   title: 'Show group ongoing/upcoming competition',
-  baseCommand: '!group competition',
+  baseCommand: '!group competition {competitionId}',
   options: [
     {
       flag: '--ongoing / --upcoming',
       description: 'Toggles between showing an ongoing or upcoming competition.'
     }
   ],
-  examples: ['!group competition', '!group competition --ongoing', '!group competition --upcoming']
+  examples: ['!group competition', '!group competition --ongoing', '!group competition --upcoming', '!group competition 139']
 };


### PR DESCRIPTION
* CompetitionID argument added to group competitions information.